### PR TITLE
rofi: better mouse support

### DIFF
--- a/archcraft-skeleton/files/rofi/config.rasi
+++ b/archcraft-skeleton/files/rofi/config.rasi
@@ -5,4 +5,8 @@ configuration {
   cycle:              false;
   hide-scrollbar:     true;
   disable-history:    false;
+  hover-select:       true;
+  me-select-entry:    "MousePrimary";
+  me-accept-entry:    "!MousePrimary";
+  me-accept-custom:   "!Control+MousePrimary";
 }


### PR DESCRIPTION
# Issue
Currently there is no entry selection on mouse hovering inside rofi menus and you have to use a double left click to confirm a selection instead of a single left click. (A single click is a better user experience in my opinion for using menus, especially on trackpads)

# Solution
New config entry wich improve rofi menu navigation and selection with mouse pointers.
It adds:
- Select entry when hovering with mouse
- Accept entry on single left click release
- Accept custom on control + single left click release

This also fixes another issue for which I had previously proposed [another fix](https://github.com/archcraft-os/archcraft-openbox/pull/7) but found that if you accept the entries on the release of the click/double click (with the `!` character) it prevents any accidental closing of the next rofi menu.

Overall I think this is a better solution and it works with all menus where as the other fix was only for the powermenu.
(I will be closing [the previous fix](https://github.com/archcraft-os/archcraft-openbox/pull/7) after submitting this PR)
